### PR TITLE
fix: ignore scripts.sil.org links

### DIFF
--- a/docs-hub/mlc.mdbook.json
+++ b/docs-hub/mlc.mdbook.json
@@ -18,6 +18,9 @@
       },
       {
         "pattern": "adobe\\.com"
+      },
+      {
+        "pattern": "scripts.sil.org"
       }
     ]
   }

--- a/docs-hub/mlc.next.json
+++ b/docs-hub/mlc.next.json
@@ -20,6 +20,9 @@
       "pattern": "adobe\\.com"
     },
     {
+      "pattern": "scripts.sil.org"
+    },
+    {
       "pattern": "^\\.\\."
     },
     {


### PR DESCRIPTION
Checks for this link sometimes fail, even though there is no issue with the link: http://scripts.sil.org/OFL. This PR removes this site from being checked by markdown-link-check.