### PR TITLE
docs(mlc): ignore versioned docs.rs links used by fuels-rs book

### DIFF
--- a/docs-hub/mlc.mdbook.json
+++ b/docs-hub/mlc.mdbook.json
@@ -18,6 +18,9 @@
       },
       {
         "pattern": "adobe\\.com"
+      },
+      {
+        "pattern": "docs\\.rs/[\\w_-]+/{{versions\\.[\\w_-]+}}"
       }
     ]
   }


### PR DESCRIPTION
In https://github.com/FuelLabs/fuels-rs/pull/1098, a new format for documentation links in `fuels-rs` book is introduced to allow for versioned Rust docs links. Examples:

- `docs.rs/fuels/{{versions.fuels}}/fuels/...`
- `docs.rs/fuels-types/{{versions.fuels_types}}/fuels-types/...`

These variables will be replaced with actual versions at build time. However, the link checker (MLC) runs on `.md` files before the build, and as such flags these links as incorrect.

My current solution is to ignore these links in the checker for now, unless some post-build checking (or similar) is implemented at a later date.