### PR TITLE
ci: add pre-command input to mdbook-docs.yml

### DIFF
--- a/.github/workflows/mdbook-docs.yml
+++ b/.github/workflows/mdbook-docs.yml
@@ -11,7 +11,7 @@ on:
         description: "a command to run before the jobs"
         required: false
         type: string
-        default: ""
+        default: ''
 
 jobs: 
   markdown-link-check:
@@ -26,7 +26,7 @@ jobs:
           repository: 'FuelLabs/github-actions'
           path: 'workflow'
       - name: Run pre-command
-        if: inputs.pre-command != ""
+        if: inputs.pre-command != ''
         run: ${{ inputs.pre-command }}
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.12
         with:
@@ -44,7 +44,7 @@ jobs:
           repository: 'FuelLabs/github-actions'
           path: 'workflow'
       - name: Run pre-command
-        if: inputs.pre-command != ""
+        if: inputs.pre-command != ''
         run: ${{ inputs.pre-command }}
       - uses: actions/setup-node@v3
         with:
@@ -65,7 +65,7 @@ jobs:
           repository: 'FuelLabs/github-actions'
           path: 'workflow'
       - name: Run pre-command
-        if: inputs.pre-command != ""
+        if: inputs.pre-command != ''
         run: ${{ inputs.pre-command }}
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/mdbook-docs.yml
+++ b/.github/workflows/mdbook-docs.yml
@@ -7,6 +7,11 @@ on:
         description: "the folder where SUMMARY.md lives"
         required: true
         type: string
+      pre-command:
+        description: "a command to run before the jobs"
+        required: false
+        type: string
+        default: ""
 
 jobs: 
   markdown-link-check:
@@ -20,6 +25,9 @@ jobs:
         with: 
           repository: 'FuelLabs/github-actions'
           path: 'workflow'
+      - name: Run pre-command
+        if: inputs.pre-command != ""
+        run: ${{ inputs.pre-command }}
       - uses: gaurav-nelson/github-action-markdown-link-check@1.0.12
         with:
           config-file: 'workflow/docs-hub/mlc.mdbook.json'
@@ -35,6 +43,9 @@ jobs:
         with: 
           repository: 'FuelLabs/github-actions'
           path: 'workflow'
+      - name: Run pre-command
+        if: inputs.pre-command != ""
+        run: ${{ inputs.pre-command }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -53,6 +64,9 @@ jobs:
         with: 
           repository: 'FuelLabs/github-actions'
           path: 'workflow'
+      - name: Run pre-command
+        if: inputs.pre-command != ""
+        run: ${{ inputs.pre-command }}
       - name: Setup node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This allows running an extra command before the jobs in `mdbook-docs.yml`. This is needed to run a replacer script when running on `fuels-rs` side.