### PR TITLE
refactor: next links check

### DIFF
--- a/.github/workflows/next-docs.yml
+++ b/.github/workflows/next-docs.yml
@@ -13,22 +13,6 @@ on:
         type: string
 
 jobs: 
-  markdown-link-check:
-    name: Check Links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: Checkout repo2
-        uses: actions/checkout@v3
-        with: 
-          repository: 'FuelLabs/github-actions'
-          path: 'workflow'
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.12
-        with:
-          config-file: 'workflow/docs-hub/mlc.next.json'
-          file-extension: 'mdx'
-
   check-doc-folders:
     name: Check Configs, Components, & Folders
     runs-on: ubuntu-latest

--- a/.github/workflows/next-links.yml
+++ b/.github/workflows/next-links.yml
@@ -11,6 +11,11 @@ on:
           description: "PR preview URL"
           required: true
           type: string
+        folder-path:
+          description: "only check mdx links in this folder"
+          required: false
+          type: string
+          default: "."
 
 jobs:
   check-links:
@@ -37,3 +42,4 @@ jobs:
           with:
             config-file: 'workflow/docs-hub/mlc.next.json'
             file-extension: 'mdx'
+            folder-path: ${{ inputs.folder-path }}

--- a/.github/workflows/next-links.yml
+++ b/.github/workflows/next-links.yml
@@ -1,0 +1,29 @@
+name: Next Links
+
+on:
+    deployment_status
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout repo
+          uses: actions/checkout@v3
+        - name: Checkout repo2
+          uses: actions/checkout@v3
+          with: 
+            repository: 'FuelLabs/github-actions'
+            path: 'workflow'
+        # SETUP NODE
+        - name: Setup node
+          uses: actions/setup-node@v3
+          with:
+            node-version: 18
+        # RUN SCRIPT TO USE VERCEL PREVIEW LINK FROM PR
+        - name: Update preview link
+          run: node workflow/docs-hub/generate-mlc-config.mjs ${{ github.event.deployment_status.state }} ${{ github.event.deployment_status.environment_url }}
+        # RUN LINK CHECK
+        - uses: gaurav-nelson/github-action-markdown-link-check@1.0.12
+          with:
+            config-file: 'workflow/docs-hub/mlc.next.json'
+            file-extension: 'mdx'

--- a/.github/workflows/next-links.yml
+++ b/.github/workflows/next-links.yml
@@ -23,6 +23,7 @@ jobs:
           with: 
             repository: 'FuelLabs/github-actions'
             path: 'workflow'
+            ref: sarah/next-links-check
         # SETUP NODE
         - name: Setup node
           uses: actions/setup-node@v3

--- a/.github/workflows/next-links.yml
+++ b/.github/workflows/next-links.yml
@@ -28,7 +28,6 @@ jobs:
           with: 
             repository: 'FuelLabs/github-actions'
             path: 'workflow'
-            ref: sarah/next-links-check
         # SETUP NODE
         - name: Setup node
           uses: actions/setup-node@v3

--- a/.github/workflows/next-links.yml
+++ b/.github/workflows/next-links.yml
@@ -1,7 +1,16 @@
 name: Next Links
 
 on:
-    deployment_status
+    workflow_call:
+      inputs:
+        status:
+          description: "deployment status, should be 'success'"
+          required: true
+          type: string
+        preview-url:
+          description: "PR preview URL"
+          required: true
+          type: string
 
 jobs:
   check-links:
@@ -21,7 +30,7 @@ jobs:
             node-version: 18
         # RUN SCRIPT TO USE VERCEL PREVIEW LINK FROM PR
         - name: Update preview link
-          run: node workflow/docs-hub/generate-mlc-config.mjs ${{ github.event.deployment_status.state }} ${{ github.event.deployment_status.environment_url }}
+          run: node workflow/docs-hub/generate-mlc-config.mjs ${{ inputs.status }} ${{ inputs.preview-url }}
         # RUN LINK CHECK
         - uses: gaurav-nelson/github-action-markdown-link-check@1.0.12
           with:

--- a/docs-hub/README.md
+++ b/docs-hub/README.md
@@ -44,6 +44,8 @@ This workflow:
 
 ### How to use?
 
+#### Docs
+
 ```yml
 uses: FuelLabs/github-actions/.github/workflows/next-docs.yml@master
 with:
@@ -51,12 +53,40 @@ with:
     src-folder-path: 'src'
 ```
 
+#### Links
+
+```yml
+name: Links
+
+on:
+    deployment_status
+
+jobs:
+    check-links:
+        uses: FuelLabs/github-actions/.github/workflows/next-links.yml@master
+        with:
+          status: ${{ github.event.deployment_status.state }}
+          preview-url: ${{ github.event.deployment_status.environment_url }}
+    
+
+```
+
 ### Inputs
+
+#### Docs
 
 | Name         | Description  |
 | ------------ | ------------ |
 | doc-folder-path | the folder path where the mdx files live |
 | src-folder-path | the src folder where the nav.json and components.json files live |
+
+#### Links
+
+| Name         | Description  |
+| ------------ | ------------ |
+| status | deployment status, should be 'success' |
+| preview-url | PR preview URL |
+| folder-path | optional: only check mdx links in this folder |
 
 ### Outputs
 
@@ -64,15 +94,20 @@ No outputs defined
 
 ### What's included
 
+#### Docs
+
 This workflow:
 
-1. Runs a link check on all links found in markdown files. You can add regex patterns to ignore certain types of links in the [mlc.next.json](mlc.next.json) config file.
-2. Checks for to make sure there are no nested subfolders.
-3. Checks to make sure the there is a nav.json file in the src folder with a menu and submenu arays.
-4. Checks for a components.json file in the src folder with folders and ignore arrays. The `folders` array should contain all of the paths where MDX components live. The `ignore` array should have all of the components that are handled explicity in the Docs Hub.
-6. Checks to make sure the names of components used in MDX files match the file name.
-7. Checks to make sure MDX components aren't nested more than twice. For example, `Examples.Events.Connect` & `Examples.Connect` are ok
+1. Checks for to make sure there are no nested subfolders.
+2. Checks to make sure the there is a nav.json file in the src folder with a menu and submenu arays.
+3. Checks for a components.json file in the src folder with folders and ignore arrays. The `folders` array should contain all of the paths where MDX components live. The `ignore` array should have all of the components that are handled explicity in the Docs Hub.
+4. Checks to make sure the names of components used in MDX files match the file name.
+5. Checks to make sure MDX components aren't nested more than twice. For example, `Examples.Events.Connect` & `Examples.Connect` are ok
 `Examples.Events.Connect.First` is not ok.
+
+#### Links
+
+This workflow checks all links in mdx files.
 
 ## Vitepress
 

--- a/docs-hub/generate-mlc-config.mjs
+++ b/docs-hub/generate-mlc-config.mjs
@@ -1,0 +1,19 @@
+import fs from 'fs';
+
+main();
+
+function main() {
+  const deploymentState = process.argv[2];
+  console.log('DEPLOYMENT STATE:', deploymentState);
+  const deploymentURL = process.argv[3];
+  console.log('DEPLOYMENT URL:', deploymentURL);
+
+  if (deploymentState === 'success' && deploymentURL) {
+    const configPath = './workflow/docs-hub/mlc.next.json';
+    const configFile = fs.readFileSync(configPath, 'utf-8');
+    const newContent = configFile.replace('{{VERCEL_PREVIEW}}', deploymentURL);
+    fs.writeFileSync(configPath, newContent);
+  } else {
+    throw Error('MISSING VERCEL DEPLOYMENT');
+  }
+}

--- a/docs-hub/mlc.next.json
+++ b/docs-hub/mlc.next.json
@@ -23,9 +23,6 @@
       "pattern": "scripts.sil.org"
     },
     {
-      "pattern": "^\\.\\."
-    },
-    {
       "pattern": "^@repository"
     },
     {
@@ -33,6 +30,12 @@
     },
     {
       "pattern": "\\.png$"
+    }
+  ],
+  "replacementPatterns": [
+    {
+      "pattern": "^(/)(.*)",
+      "replacement": "{{VERCEL_PREVIEW}}/$2"
     }
   ]
 }

--- a/docs-hub/mlc.next.json
+++ b/docs-hub/mlc.next.json
@@ -11,6 +11,9 @@
       "pattern": "crates\\.io"
     },
     {
+      "pattern": "infura\\.io"
+    },
+    {
       "pattern": "-indexer.fuel.network"
     },
     {


### PR DESCRIPTION
This PR separates the markdown link check from the `next-docs.yml` into a new file `next-links.yml`. The link checker previously ignored relative links in next docs because it wasn't supported OOTB. This new link checker workflow is configured to use the Vercel preview from the PR to check all links in any next docs.

See it working here:
https://github.com/FuelLabs/fuels-wallet/pull/944
https://github.com/FuelLabs/fuel-graphql-docs/pull/24
https://github.com/FuelLabs/docs-hub/pull/91