### PR TITLE
Pretend 403 return code means a link is alive

### DIFF
--- a/docs-hub/mlc.mdbook.json
+++ b/docs-hub/mlc.mdbook.json
@@ -1,5 +1,5 @@
 {
-  "aliveStatusCodes": [200, 206, 405],
+  "aliveStatusCodes": [200, 206, 403, 405],
   "ignorePatterns": [
     {
       "pattern": "localhost:"


### PR DESCRIPTION
See https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/185

Related: https://github.com/FuelLabs/fuel-specs/issues/547