### PR TITLE
fix: ignore links to hidden devrel repo

### DIFF
--- a/docs-hub/mlc.mdbook.json
+++ b/docs-hub/mlc.mdbook.json
@@ -24,6 +24,9 @@
     },
     {
       "pattern": "^https://twitter.com"
+    },
+    {
+      "pattern": "^https://github.com/FuelLabs/devrel-requests"
     }
   ]
 }


### PR DESCRIPTION
Allow linking to devrel-requests repo for our PR template, would 404 otherwise