### PR TITLE
ci(link-checker): use lychee instead of MLC

### DIFF
--- a/.github/workflows/mdbook-docs.yml
+++ b/.github/workflows/mdbook-docs.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
+          key: cache-lychee-${{ github.ref_name }}
           restore-keys: cache-lychee-
       - uses: lycheeverse/lychee-action@v1
         with:

--- a/.github/workflows/mdbook-docs.yml
+++ b/.github/workflows/mdbook-docs.yml
@@ -32,9 +32,15 @@ jobs:
       - name: Run pre-command
         if: inputs.pre-command != ''
         run: ${{ inputs.pre-command }}
-      - uses: gaurav-nelson/github-action-markdown-link-check@1.0.12
+      - name: Restore lychee cache
+        uses: actions/cache@v3
         with:
-          config-file: 'workflow/docs-hub/mlc.mdbook.json'
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+      - uses: lycheeverse/lychee-action@v1
+        with:
+          args: '--config workflow/docs-hub/lychee.toml'
 
   markdown-lint:
     name: Markdown Lint

--- a/docs-hub/lychee.toml
+++ b/docs-hub/lychee.toml
@@ -1,0 +1,26 @@
+# Enable link caching. This can be helpful to avoid checking the same links on
+# multiple runs.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "1d"
+
+# Comma-separated list of accepted status codes for valid links.
+accept = ["200", "206", "405"]
+
+# Exclude URLs and mail addresses from checking (supports regex).
+exclude = [
+    'localhost:',
+    '^http://[1-9]',
+    'crates\\.io',
+    'faucet-beta-5.fuel.network',
+    '-indexer.fuel-network',
+    'fuellabs.github.io/block-explorer-v2',
+    'adobe\\.com',
+    'scripts.sil.org',
+]
+
+# Exclude all private IPs from checking.
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and
+# `exclude_loopback` to true.
+exclude_all_private = true

--- a/docs-hub/lychee.toml
+++ b/docs-hub/lychee.toml
@@ -10,14 +10,8 @@ accept = ["200", "206", "405"]
 
 # Exclude URLs and mail addresses from checking (supports regex).
 exclude = [
-    'localhost:',
-    '^http://[1-9]',
-    'crates\\.io',
     'faucet-beta-5.fuel.network',
-    '-indexer.fuel-network',
     'fuellabs.github.io/block-explorer-v2',
-    'adobe\\.com',
-    'scripts.sil.org',
 ]
 
 # Exclude all private IPs from checking.


### PR DESCRIPTION
This PR changes [`mdbook-docs.yml`](../blob/master/.github/workflows/mdbook-docs.yml#L35) workflow to use https://github.com/lycheeverse/lychee ("Fast, async, stream-based link checker written in Rust") via https://github.com/lycheeverse/lychee-action instead of MLC (`markdown-link-check`).

The lychee config file ([`lychee.toml`](../blob/lychee-link-checker/docs-hub/lychee.toml)) closely mirrors the settings from existing [`mlc.mdbook.json`](../blob/master/docs-hub/mlc.mdbook.json), and thus should work with any and all Markdown files. I opted to leave `mlc.next.json` as-is for now, because it uses extra configuration.

Reasoning for the change:
- main reason - `markdown-link-check` operates on individual files (e.g., `find . -name *md -exec markdown-link-check {};`). This means that the errors are reported in the middle of the job output, which is quite long. Thus, it is difficult to find the actual error message. `lychee` uses globs like `**/*.md` natively (handled by `lychee-action` under the hood), meaning that there's a single report for all links in the repo's Markdown, with errors clearly visible. It looks like this by default (1 link failing on purpose):
```
  179/179 ━━━━━━━━━━━━━━━━━━━━ Finished extracting links                                                                                                                                                                                             Issues found in 1 input. Find details below.

[docs/src/connecting/external-node.md]:
✗ [403] https://faucet-beta-5.fuel.network/ | Failed: Network error: Forbidden

🔍 179 Total (in 1s) ✅ 177 OK 🚫 1 Error 💤 1 Excluded
```
- `lychee` can use GHA cache to avoid checking the same links on repeated CI runs - this is configured in this PR
- it's much faster than MLC, written in Rust and well-maintained (+ for security)
