### PR TITLE
chore: remove node modules from cache

### DIFF
--- a/setups/node/action.yaml
+++ b/setups/node/action.yaml
@@ -17,7 +17,6 @@ runs:
         path: |
           ~/.local/share/pnpm/store/v3
           ~/.pnpm-store
-          **/node_modules
         key: ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-${{ inputs.pnpm-version }}-lock-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-${{ inputs.pnpm-version }}-lock-


### PR DESCRIPTION
- Remove node modules cache to avoid creating conflicts