### PR TITLE
chore: remove docs validation for ts sdk api docs

### DIFF
--- a/docs-hub/vp-docs.js
+++ b/docs-hub/vp-docs.js
@@ -7,12 +7,10 @@ const srcFolderPath = path.join(process.cwd(), `../../${process.argv[2]}`);
 const subfolders = getSubfolders(srcFolderPath);
 
 const configPath = path.join(srcFolderPath, "../.vitepress/config.ts");
-const apiOrderPath = path.join(srcFolderPath, "../.typedoc/api-links.json");
 
 const configFile = fs.readFileSync(configPath, "utf8");
-const apiOrderFile = fs.readFileSync(apiOrderPath, "utf8");
 
-const subFolderExceptions = ["guide", "api"];
+const subFolderExceptions = ["guide"];
 
 function main() {
   checkForIndexFile(srcFolderPath);
@@ -79,7 +77,6 @@ function checkForUnusedFiles(srcFolderPath, subfolders) {
   const fileNames = fs.readdirSync(srcFolderPath);
   fileNames.forEach((file) => {
     if (
-      file !== "api" &&
       file !== "public" &&
       file !== "index.md" &&
       (file.endsWith("md") || file.split(".").length === 1)
@@ -94,29 +91,6 @@ function checkForUnusedFiles(srcFolderPath, subfolders) {
     const folderPath = path.join(srcFolderPath, folder);
     const subfolderNames = fs.readdirSync(folderPath);
     const parentFolder = folderPath.split("/").pop();
-    subfolderNames.forEach((subFile) => {
-      if (parentFolder !== "api") {
-        const actualPath = `${parentFolder}/${
-          subFile === "index.md" ? "" : subFile
-        }`;
-        assert(
-          configFile.includes(actualPath),
-          `${actualPath} missing in the nav config`
-        );
-        const fullPath = path.join(srcFolderPath, actualPath);
-        if (fs.statSync(fullPath).isDirectory()) {
-          const subFolderFiles = fs.readdirSync(fullPath);
-          subFolderFiles.forEach((file) => {
-            if (file !== "index.md") {
-              assert(
-                configFile.includes(file.replace(".md", "")),
-                `${file} missing in the nav config`
-              );
-            }
-          });
-        }
-      }
-    });
   });
 }
 
@@ -199,7 +173,7 @@ function checkOrder(order, altSrcFolderPath = null) {
         }
         assert(
           fileExists,
-          `${item} doesn't exist. The file name must match the title in the nav config. If this file is in the API folder, something went wrong.`
+          `${item} doesn't exist. The file name must match the title in the nav config.`
         );
       });
     }
@@ -207,7 +181,6 @@ function checkOrder(order, altSrcFolderPath = null) {
 }
 
 function extractData(inputString) {
-  // used for api.json order
   const regex = /"([^"]+)":\s*"([^"]+)"/g;
   const match = regex.exec(inputString);
   if (match !== null) {
@@ -262,23 +235,6 @@ function handleVPLine(trimmedLine, lines, index, thisOrder, thisCat) {
         newVPOrder.menu.push(linkName);
       }
     }
-  } else if (trimmedLine.startsWith("apiLinks")) {
-    // handle API order
-    newVPOrder.menu.push("API");
-    const apiJSON = JSON.parse(apiOrderFile);
-    const apiLines = JSON.stringify(apiJSON, null, 2).split(EOL);
-    apiLines.forEach((apiLine, apiIndex) => {
-      const trimmedAPILine = apiLine.trimStart();
-      const results = handleVPLine(
-        trimmedAPILine,
-        apiLines,
-        apiIndex,
-        newVPOrder,
-        category
-      );
-      category = results.category;
-      newVPOrder = results.newVPOrder;
-    });
   }
 
   return { newVPOrder, category };


### PR DESCRIPTION
This PR removes the validation in place for the TS SDK API docs since they have now been isolated in a different project on a different URL (https://github.com/FuelLabs/fuels-ts/pull/3237) and they are now only referenced from the 'main' TS SDK docs.