### PR TITLE
chore: reinstate incorrectly removed code block

### DIFF
--- a/docs-hub/vp-docs.js
+++ b/docs-hub/vp-docs.js
@@ -10,7 +10,7 @@ const configPath = path.join(srcFolderPath, "../.vitepress/config.ts");
 
 const configFile = fs.readFileSync(configPath, "utf8");
 
-const subFolderExceptions = ["guide"];
+const subFolderExceptions = ["guide", "api"];
 
 function main() {
   checkForIndexFile(srcFolderPath);

--- a/docs-hub/vp-docs.js
+++ b/docs-hub/vp-docs.js
@@ -91,6 +91,27 @@ function checkForUnusedFiles(srcFolderPath, subfolders) {
     const folderPath = path.join(srcFolderPath, folder);
     const subfolderNames = fs.readdirSync(folderPath);
     const parentFolder = folderPath.split("/").pop();
+    subfolderNames.forEach((subFile) => {
+      const actualPath = `${parentFolder}/${
+        subFile === "index.md" ? "" : subFile
+      }`;
+      assert(
+        configFile.includes(actualPath),
+        `${actualPath} missing in the nav config`
+      );
+      const fullPath = path.join(srcFolderPath, actualPath);
+      if (fs.statSync(fullPath).isDirectory()) {
+        const subFolderFiles = fs.readdirSync(fullPath);
+        subFolderFiles.forEach((file) => {
+          if (file !== "index.md") {
+            assert(
+              configFile.includes(file.replace(".md", "")),
+              `${file} missing in the nav config`
+            );
+          }
+        });
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Closes #44

# Summary

- Reinstated previous behaviour.
- Removed redundant if clause as the `api` directory now won't exist.
- Re-added the `api` folder to the `subFolderExceptions` to avoid blocking the TS SDK CI.