### PR TITLE
chore: added snippets ignore

### DIFF
--- a/docs-hub/vp-docs.js
+++ b/docs-hub/vp-docs.js
@@ -53,6 +53,7 @@ function getNestedFolders(subfolders, folderPath) {
 
 function checkForNestedFolders(subfolders, srcFolderPath) {
   const nestedSubfolders = getNestedFolders(subfolders, srcFolderPath);
+  console.log("Nested sub folders", nestedSubfolders)
   if (nestedSubfolders.length > 0) {
     nestedSubfolders.forEach((folder) => {
       assert(

--- a/docs-hub/vp-docs.js
+++ b/docs-hub/vp-docs.js
@@ -3,6 +3,9 @@ import fs from "fs";
 import { EOL } from "os";
 import path from "path";
 
+const subFolderExceptions = ["guide", "api"];
+const subFolderIgnore = ['snippets'];
+
 const srcFolderPath = path.join(process.cwd(), `../../${process.argv[2]}`);
 const subfolders = getSubfolders(srcFolderPath);
 
@@ -11,8 +14,6 @@ const apiOrderPath = path.join(srcFolderPath, "../.typedoc/api-links.json");
 
 const configFile = fs.readFileSync(configPath, "utf8");
 const apiOrderFile = fs.readFileSync(apiOrderPath, "utf8");
-
-const subFolderExceptions = ["guide", "api"];
 
 function main() {
   checkForIndexFile(srcFolderPath);
@@ -35,7 +36,8 @@ function getSubfolders(folderPath) {
     .filter(
       (item) =>
         fs.statSync(path.join(folderPath, item)).isDirectory() &&
-        item !== "public"
+        item !== "public" &&
+        !subFolderIgnore.includes(item)
     );
 }
 
@@ -79,6 +81,7 @@ function checkForUnusedFiles(srcFolderPath, subfolders) {
   const fileNames = fs.readdirSync(srcFolderPath);
   fileNames.forEach((file) => {
     if (
+      !subFolderIgnore.includes(item) &&
       file !== "api" &&
       file !== "public" &&
       file !== "index.md" &&


### PR DESCRIPTION
# Summary

Added `subFolderIgnore` to ignore the `snippets` directory from the docs-hub checks.

This is required for the following [PR](https://github.com/FuelLabs/fuels-ts/pull/3369).