### PR TITLE
upd checkForNestedFolders function to allow multiple subdirectories i…

### DIFF
--- a/docs-hub/mdbook-docs.js
+++ b/docs-hub/mdbook-docs.js
@@ -69,14 +69,15 @@ function checkForNestedFolders(subfolders, srcFolderPath) {
         "cannot have nested subfolders"
       );
       if (folder === "plugins") {
+        // Allow plugins folder to have any subdirectories
         const pluginsPath = path.join(srcFolderPath, folder);
         const pluginSubFolders = fs
           .readdirSync(pluginsPath)
           .filter((item) =>
             fs.statSync(path.join(srcFolderPath, folder, item)).isDirectory()
           );
-        assert.deepStrictEqual(pluginSubFolders.length, 1);
-        assert.deepStrictEqual(pluginSubFolders[0], "forc_client");
+        // Ensure plugins folder is not empty
+        assert(pluginSubFolders.length > 0, "plugins folder must have at least one subdirectory");
       }
     });
   }
@@ -112,11 +113,12 @@ function checkForUnusedFiles(srcFolderPath, subfolders) {
     const subfolderNames = fs.readdirSync(folderPath);
     const parentFolder = folderPath.split("/").pop();
     subfolderNames.forEach((subFile) => {
-      if(subFile === 'forc_client'){
-        const forcClientPath = path.join(folderPath, subFile);
-        const forcClientSubfolderNames = fs.readdirSync(forcClientPath);
-        forcClientSubfolderNames.forEach((forcClientSubFile) => {
-          const actualPath = `${subFile}/${forcClientSubFile}`;
+      const subFilePath = path.join(folderPath, subFile);
+      // Check if it's a directory that might have nested files
+      if(fs.statSync(subFilePath).isDirectory()){
+        const nestedFiles = fs.readdirSync(subFilePath);
+        nestedFiles.forEach((nestedFile) => {
+          const actualPath = `${subFile}/${nestedFile}`;
           assert(
             summaryContent.includes(actualPath),
             `${actualPath} missing in SUMMARY.md`
@@ -178,13 +180,20 @@ function checkOrder(order, altSrcFolderPath = null) {
               fileExists = true;
               break;
             } else {
-              itemPath = path.join(
-                srcPath,
-                `${key !== "forc" ? `${key}/forc_client/` : "/"}${item}.md`
-              );
-              if (fs.existsSync(itemPath)) {
-                fileExists = true;
-                break;
+              // Search for file in nested subdirectories
+              // When key is "forc", srcPath already points to the forc directory
+              // For other keys, append the key to srcPath to get the parent directory
+              const parentPath = key !== "forc" ? path.join(srcPath, key) : srcPath;
+              if (fs.existsSync(parentPath)) {
+                const subdirs = fs.readdirSync(parentPath)
+                  .filter(dir => fs.statSync(path.join(parentPath, dir)).isDirectory());
+                for (const subdir of subdirs) {
+                  itemPath = path.join(parentPath, subdir, `${item}.md`);
+                  if (fs.existsSync(itemPath)) {
+                    fileExists = true;
+                    break;
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
## Description

This pull request refactors the `docs-hub/mdbook-docs.js` file to improve flexibility and robustness when handling nested directories in the documentation structure.
The most notable changes include allowing the `plugins` folder to contain multiple subdirectories, updating file validation logic to support nested subfolders, and enhancing the file order verification process to handle nested structures.

### Improvements to folder handling:

* **Plugins folder flexibility**: Updated the `checkForNestedFolders` function to allow the `plugins` folder to contain any number of subdirectories, as long as it is not empty. Previously, it was restricted to a single subfolder named `forc_client`.

* **Support for nested files in subdirectories**: Modified the `checkForUnusedFiles` function to validate nested files within subdirectories, ensuring they are referenced in `SUMMARY.md`. This replaces the previous logic that was specific to the `forc_client` folder.

### Enhancements to file order validation:

* **Dynamic handling of nested subdirectories**: Updated the `checkOrder` function to dynamically search for `.md` files in nested subdirectories, accommodating varying directory structures. This change removes hardcoded paths and improves adaptability for different keys in the documentation hierarchy.